### PR TITLE
update blacklist for tinker islands

### DIFF
--- a/overrides/config/AppliedEnergistics2/AppliedEnergistics2.cfg
+++ b/overrides/config/AppliedEnergistics2/AppliedEnergistics2.cfg
@@ -239,6 +239,9 @@ features {
 
     craftingfeatures {
         B:CraftingCPU=true
+
+        # Use CraftingManager to find an alternative recipe, after a pattern rejected an ingredient. Should be enabled to avoid issues, but can have a minor performance impact.
+        B:CraftingManagerFallback=true
         B:MolecularAssembler=true
         B:Patterns=true
     }
@@ -354,6 +357,9 @@ orecamouflage {
     # OreDictionary Names: dustEnder,dustEnderPearl
     B:ENDER_DUST=true
 
+    # OreDictionary Names: dustWheat
+    B:FLOUR=false
+
     # OreDictionary Names: dustGold
     B:GOLD_DUST=true
 
@@ -362,6 +368,9 @@ orecamouflage {
 
     # OreDictionary Names: dustNetherQuartz
     B:NETHER_QUARTZ_DUST=true
+
+    # OreDictionary Names: itemSilicon
+    B:SILICON=false
 
     # OreDictionary Names: gearWood
     B:WOODEN_GEAR=true

--- a/overrides/config/environmentaltech/multiblocks/void_miner/ore/tier_1.json
+++ b/overrides/config/environmentaltech/multiblocks/void_miner/ore/tier_1.json
@@ -203,7 +203,7 @@
     {
       "target": "black",
       "weight": 222,
-      "id": "OD:oreThroium"
+      "id": "OD:oreThorium"
     },
     {
       "target": "siver",

--- a/overrides/config/environmentaltech/multiblocks/void_miner/ore/tier_3.json
+++ b/overrides/config/environmentaltech/multiblocks/void_miner/ore/tier_3.json
@@ -228,7 +228,7 @@
     {
       "target": "black",
       "weight": 222,
-      "id": "OD:oreThroium"
+      "id": "OD:oreThorium"
     },
     {
       "target": "siver",

--- a/overrides/config/environmentaltech/multiblocks/void_miner/ore/tier_4.json
+++ b/overrides/config/environmentaltech/multiblocks/void_miner/ore/tier_4.json
@@ -233,7 +233,7 @@
     {
       "target": "black",
       "weight": 222,
-      "id": "OD:oreThroium"
+      "id": "OD:oreThorium"
     },
     {
       "target": "siver",

--- a/overrides/config/environmentaltech/multiblocks/void_miner/ore/tier_5.json
+++ b/overrides/config/environmentaltech/multiblocks/void_miner/ore/tier_5.json
@@ -238,7 +238,7 @@
     {
       "target": "black",
       "weight": 222,
-      "id": "OD:oreThroium"
+      "id": "OD:oreThorium"
     },
     {
       "target": "siver",

--- a/overrides/config/environmentaltech/multiblocks/void_miner/ore/tier_6.json
+++ b/overrides/config/environmentaltech/multiblocks/void_miner/ore/tier_6.json
@@ -238,7 +238,7 @@
     {
       "target": "black",
       "weight": 222,
-      "id": "OD:oreThroium"
+      "id": "OD:oreThorium"
     },
     {
       "target": "siver",

--- a/overrides/config/forestry/common.cfg
+++ b/overrides/config/forestry/common.cfg
@@ -155,6 +155,11 @@ tweaks {
         I:ring_size=4
     }
 
+    book {
+        # Players who enter the world for the first time get a Forester's Manual. [default: true]
+        B:spawn=false
+    }
+
 }
 
 
@@ -182,6 +187,8 @@ world {
             # Force Forestry to generate a beehive at every possible location. (This will break your world. Only useful to developers) [default: false]
             B:debug=false
             I:dimBlacklist <
+             >
+            I:dimWhitelist <
              >
 
             ##########################################################################################################
@@ -221,6 +228,8 @@ world {
             B:copper=false
             I:dimBlacklist <
              >
+            I:dimWhitelist <
+             >
 
             # Generates tin ore blocks in the world. [default: true]
             B:tin=false
@@ -228,6 +237,8 @@ world {
 
         trees {
             I:dimBlacklist <
+             >
+            I:dimWhitelist <
              >
         }
 

--- a/overrides/config/plustic.cfg
+++ b/overrides/config/plustic.cfg
@@ -191,7 +191,7 @@ modules {
     B:"Enable Draconic Evolution integration"=true
 
     # Integrate with EnderIO [default: true]
-    B:"Enable EnderIO integration"=true
+    B:"Enable EnderIO integration"=false
 
     # Integrate with Environmental Tech [default: true]
     B:"Enable Environmental Tech support"=true

--- a/overrides/config/tconstruct.cfg
+++ b/overrides/config/tconstruct.cfg
@@ -95,9 +95,21 @@ worldgen {
     I:magmaIslandRate=90
 
     # Prevents generation of slime islands in the listed dimensions
+	# deep dark, nether, the end, twilight forest, betweenlands, underworld, abyssal wasteland, dreadlands, omothol, dark realm, comapact machines, tartarus, wasteland
     I:slimeIslandBlacklist <
+		-9999
         -1
         1
+		7
+		20
+		33
+		50
+		51
+		52
+		53
+		144
+		418
+		4598
      >
 
     # If true, slime islands wont generate in dimensions which aren't of type surface. This means they wont generate in modded cave dimensions like the deep dark.

--- a/overrides/config/ynot.cfg
+++ b/overrides/config/ynot.cfg
@@ -2,10 +2,10 @@
 
 balance {
     # Maximum transfer rate for Mekanism Gas and advanced connectors [range: 1 ~ 2147483647, default: 1280]
-    I:mekanismGasMaxRateAdvanced=1280
+    I:mekanismGasMaxRateAdvanced=5120
 
     # Maximum transfer rate for Mekanism Gas and normal connectors [range: 1 ~ 2147483647, default: 256]
-    I:mekanismGasMaxRateNormal=256
+    I:mekanismGasMaxRateNormal=1280
 }
 
 

--- a/overrides/scripts/atm_general_akashictome.zs
+++ b/overrides/scripts/atm_general_akashictome.zs
@@ -229,6 +229,14 @@ print(" ==================================================== ");
 				},
 				Damage: 0 as short
 			},
+			woot: {
+				id: "guideapi:woot-guide",
+				Count: 1 as byte,
+				tag: {
+					"akashictome:definedMod": "woot"
+				},
+				Damage: 0 as short
+			},
 			openblocks: {
 				id: "openblocks:info_book",
 				Count: 1 as byte,
@@ -286,7 +294,8 @@ print(" ==================================================== ");
 		<embers:codex>, 
 		<rftools:rftools_shape_manual>, 
 		<guideapi:mobtotems-mobtotems_guide>, 
-		<openblocks:info_book>
+		<openblocks:info_book>,
+		<guideapi:woot-guide>
 		] as IItemStack[];
 
 	for itemBook in addedBooks {

--- a/overrides/scripts/atm_general_akashictome.zs
+++ b/overrides/scripts/atm_general_akashictome.zs
@@ -237,6 +237,14 @@ print(" ==================================================== ");
 				},
 				Damage: 0 as short
 			},
+			forestry: {
+				id: "forestry:book_forester",
+				Count: 1 as byte,
+				tag: {
+					"akashictome:definedMod": "forestry"
+				},
+				Damage: 0 as short
+			},
 			openblocks: {
 				id: "openblocks:info_book",
 				Count: 1 as byte,
@@ -295,6 +303,7 @@ print(" ==================================================== ");
 		<rftools:rftools_shape_manual>, 
 		<guideapi:mobtotems-mobtotems_guide>, 
 		<openblocks:info_book>,
+		<forestry:book_forester>,
 		<guideapi:woot-guide>
 		] as IItemStack[];
 

--- a/overrides/scripts/atm_general_misc.zs
+++ b/overrides/scripts/atm_general_misc.zs
@@ -367,5 +367,11 @@ print(" ============================================================== ");
 		[<ore:ingotIron>, null, null]
 		]);
 
-
-
+//====== TR LED Lamp ======
+//
+recipes.remove(<techreborn:lamp_led>);
+	recipes.addShaped(<techreborn:lamp_led>, [
+		[<ore:paneGlass>, <ore:paneGlass>, <ore:paneGlass>],
+		[<ic2:cable:4>.withTag({type: 4 as byte, insulation: 0 as byte}), <minecraft:glowstone_dust>, <ic2:cable:4>.withTag({type: 4 as byte, insulation: 0 as byte})],
+		[<ore:paneGlass>, <ore:paneGlass>, <ore:paneGlass>]
+		]);

--- a/overrides/scripts/atm_general_misc.zs
+++ b/overrides/scripts/atm_general_misc.zs
@@ -375,3 +375,13 @@ recipes.remove(<techreborn:lamp_led>);
 		[<ic2:cable:4>.withTag({type: 4 as byte, insulation: 0 as byte}), <minecraft:glowstone_dust>, <ic2:cable:4>.withTag({type: 4 as byte, insulation: 0 as byte})],
 		[<ore:paneGlass>, <ore:paneGlass>, <ore:paneGlass>]
 		]);
+
+//====== Enderman Skull ======
+//
+    var enderEssence = <mysticalagriculture:enderman_essence>;
+    var blankSkull = <mysticalagriculture:crafting:15>;
+    recipes.addShaped(<enderio:block_enderman_skull>, [
+        [enderEssence, enderEssence, enderEssence],
+        [enderEssence, blankSkull,   enderEssence], 
+        [enderEssence, enderEssence, enderEssence]
+        ]);

--- a/overrides/scripts/atm_general_misc.zs
+++ b/overrides/scripts/atm_general_misc.zs
@@ -385,3 +385,12 @@ recipes.remove(<techreborn:lamp_led>);
         [enderEssence, blankSkull,   enderEssence], 
         [enderEssence, enderEssence, enderEssence]
         ]);
+
+//====== Super-Frame Corner ======
+//
+recipes.remove(<funkylocomotion:mass_frame_corner>);
+	recipes.addShaped(<funkylocomotion:mass_frame_corner>, [
+		[<ore:ingotElectrum>, null, <ore:ingotElectrum>],
+		[null, <funkylocomotion:pusher:1>, null], 
+		[<ore:ingotElectrum>, null, <ore:ingotElectrum>]
+		]);

--- a/overrides/scripts/atm_oredict_ores.zs
+++ b/overrides/scripts/atm_oredict_ores.zs
@@ -5,7 +5,7 @@ import crafttweaker.oredict.IOreDictEntry;
 
 #packmode normal simplified
 
-print(" =================== ATC OreDict (ores) =================== ");
+print(" =================== ATM OreDict (ores) =================== ");
 print(" ========================================================== ");
 
 //====== Unify ores into oredicts =======
@@ -138,6 +138,13 @@ print(" ========================================================== ");
 		<techreborn:ore:10>
 		]);
 	recipes.addShapeless("peridotconvert", <techreborn:ore:10>*2, [<ore:orePeridot>, <ore:orePeridot>]);
+	//PROSPERITY
+	<ore:oreProsperity>.addItems([
+		<mysticalagriculture:prosperity_ore>,
+		<mysticalagriculture:nether_prosperity_ore>,
+		<mysticalagriculture:end_prosperity_ore>
+		]);
+	recipes.addShapeless("prosperityconvert", <mysticalagriculture:prosperity_ore>*2, [<ore:oreProsperity>, <ore:oreProsperity>]);
 	//GEM RUBY
 	<ore:oreRuby>.addItems([
 		<biomesoplenty:gem_ore:1>,

--- a/overrides/scripts/creative_items.zs
+++ b/overrides/scripts/creative_items.zs
@@ -222,10 +222,10 @@ print(" ====================================================== ");
 	<thermalexpansion:capacitor:32000>.addTooltip("Does not consume the Orb portion of the ATM Star when crafted");
 		
 	// Thermal Watering Can
-	recipes.addShapeless(<thermalcultivation:watering_can:32000>, [
+	recipes.addShapeless(<thermalcultivation:watering_can:32000>.withTag({Water: 60000, Mode: 4}), [
 		atmStarReturnOrb, <thermalcultivation:watering_can:4>
 		]);
-	<thermalcultivation:watering_can:32000>.addTooltip("Does not consume the Orb portion of the ATM Star when crafted");
+	<thermalcultivation:watering_can:32000>.withTag({Water: 60000, Mode: 4}).addTooltip("Does not consume the Orb portion of the ATM Star when crafted");
 		
 	// Mek Energy Cube
 	var creativeMekCube = <mekanism:energycube>.withTag({tier: 4, mekData: {energyStored: 1.7976931348623157E308}});
@@ -278,10 +278,10 @@ print(" ====================================================== ");
 	<waterstrainer:super_worm>.addTooltip("Does not consume the ATM Star at all when crafted");
 		
 	// CompuCraft Case
-	recipes.addShapeless(<opencomputers:casecreative>, [
-		<atmtweaks:item_material>.giveBack(), <opencomputers:case2>, <opencomputers:material:21>
-		]);
-	<opencomputers:casecreative>.addTooltip("Does not consume the ATM Star at all when crafted");
+	// recipes.addShapeless(<opencomputers:casecreative>, [
+	//	<atmtweaks:item_material>.giveBack(), <opencomputers:case2>, <opencomputers:material:21>
+	//	]);
+	//  <opencomputers:casecreative>.addTooltip("Does not consume the ATM Star at all when crafted");
 		
 	// Creative Builder's Wand
 	recipes.addShapeless(<extrautils2:itemcreativebuilderswand>, [


### PR DESCRIPTION
deep dark, nether, the end, twilight forest, betweenlands, underworld, abyssal wasteland, dreadlands, omothol, dark realm, comapact machines, tartarus, wasteland
