### PR TITLE
Enable Grain Of Infinity In All Dimensions

### DIFF
--- a/overrides/config/enderio/EnderIO.cfg
+++ b/overrides/config/enderio/EnderIO.cfg
@@ -637,7 +637,7 @@ items {
         I:dropStackSize=1
 
         # Should making Infinity Powder be allowed in all dimensions? If not, it'll only work in the overworld. (synced from server) [default: false]
-        B:enableInAllDimensions=false
+        B:enableInAllDimensions=true
 
         # How old (in ticks) does a dying fire have to be to spawn Infinity Powder? (average fire age at death is 11.5s, default is 13s (synced from server) [range: 1 ~ 1000, default: 260]
         I:fireMinAge=260


### PR DESCRIPTION
Changes EnderIO config to allow for bedrock to be lit on fire to retrieve grains of infinity in all dimensions. This is just a convenience thing.