### PR TITLE
Fix #446: remove unnecessary dimlet-related code

### DIFF
--- a/overrides/config/rftools/dimensions.cfg
+++ b/overrides/config/rftools/dimensions.cfg
@@ -28,9 +28,6 @@ dimletconstruction {
     # Amount of liquid blocks needed to fully absorb liquid essence
     I:maxLiquidAbsorbtion=512
 
-    # Amount of injections needed to get a fully absorbed mob essence
-    I:maxMobInjections=64
-
     # Amount of ticks needed to fully absorb a terrain essence
     I:maxTerrainAbsorbtion=10000
 

--- a/overrides/scripts/atm_general_misc.zs
+++ b/overrides/scripts/atm_general_misc.zs
@@ -300,23 +300,6 @@ print(" ============================================================== ");
 	recipes.addShaped(<minecraft:cookie>, [[<minecraft:wheat>, <minecraft:dye:3>, <minecraft:wheat>]]);
 
 
-//====== End Dragon Dimlet ======
-//
-	val dimletDragon = <rftoolsdim:known_dimlet:3>.withTag({dkey: "minecraft:ender_dragon"});
-	recipes.addShaped(dimletDragon, [
-		[<atmtweaks:item_material:1>, <mysticalagradditions:stuff:2>, <astralsorcery:itemcraftingcomponent:1>],
-		[<rftoolsdim:dimlet_control_circuit:6>, <minecraft:dragon_egg>, <minecraft:skull:5>],
-		[<atmtweaks:item_material:1>, <mysticalagradditions:stuff:2>, <astralsorcery:itemcraftingcomponent:1>]
-		]);
-
-	//metadata to item
-	dimletDragon.addTooltip(format.aqua("NOT crafted in the dimlet workbench"));
-	mods.jei.JEI.addDescription(dimletDragon, "Syringe has been disabled for ender dragons. Instead, a dragon mob dimlet can be crafted with a normal recipe instead");
-
-	//add the full book to JEI as it's own entry
-	mods.jei.JEI.addItem(dimletDragon);
-
-
 //====== Natura Flamestring ======
 //
 	<ore:fieryItem>.addAll(<ore:slimecrystalMagma>);


### PR DESCRIPTION
RFTools Dimensions removed its maxMobInjections setting in 5.53, instead
using the value inherited from RFTools. Remove our copy to avoid clutter.
In addition, the Ender Dragon dimlet can now be made the normal way with
a syringe and the dimlet workbench, so remove our custom recipe and info
about it. (The Ender Dragon syringe remains unusable in the Spawner.)