### PR TITLE
Update nuclearcraft.cfg Advanced Voltaic Pile was 10x stronger than it should be. 

### DIFF
--- a/overrides/config/nuclearcraft.cfg
+++ b/overrides/config/nuclearcraft.cfg
@@ -93,7 +93,7 @@ energy_storage {
     # Maximum RF storable. Order: Voltaic Pile [Basic, Advanced, DU, Elite], Lithium Ion Battery [Basic, Advanced, DU, Elite].
     I:battery_capacity <
         1600000
-        64000000
+        6400000
         25600000
         102400000
         32000000


### PR DESCRIPTION
Changed max RF storable in Advanced voltaic pile to be 4x basic and 1/4th DU instead of being 40x basic and 2.5x DU.  (It appears an extra 0 was included in the original balancing)